### PR TITLE
Allow custom underscore template settings through query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ module.exports = {
         }
     ]
 };
+```
 
 <br/>
 **Loading templates**

--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ module.exports = {
     ]
 };
 ```
+<br/>
+**Set underscore template settings**
+```javascript
+module.exports = {
+    //...
+    loaders: [
+        //...
+        {
+          test: /\.html/,
+          loader: "underscore-template-loader",
+          query: {
+            interpolate : '\\{\\[(.+?)\\]\\}',
+            evaluate: '\\{%([\\s\\S]+?)%\\}',
+            escape : '\\{\\{(.+?)\\}\\}'
+          }
+        }
+    ]
+};
 
 <br/>
 **Loading templates**

--- a/index.js
+++ b/index.js
@@ -5,20 +5,20 @@ module.exports = function() {
 	var path = require('path');
 	var fs = require('fs');
 	var includeRegex = /<!--include\s+([\/\w\.]*?[\w]+\.[\w]+)-->/g;
-	
+
 	var readFile = function(filepath, root) {
 		var self = readFile;
 		self.buffer = self.buffer || {};
-		
+
 		if (filepath in self.buffer)
 			return self.buffer[filepath];
-		
-		var content = readContent(fs.readFileSync(path.join(root, filepath), 'utf8'), root);    
+
+		var content = readContent(fs.readFileSync(path.join(root, filepath), 'utf8'), root);
 		self.buffer[filepath] = content;
 		return self.buffer[filepath];
 	};
-	
-	var readContent = function(content, root) {    
+
+	var readContent = function(content, root) {
 		var matches = includeRegex.exec(content);
 
 		while (matches != null) {
@@ -30,8 +30,15 @@ module.exports = function() {
 
 		return content;
 	};
-	
+
 	return function(content) {
+		if (this.query.length) {
+			var query = loaderUtils.parseQuery(this.query);
+			_.each(query, function(value, key){
+				_.templateSettings[key] = new RegExp(value, 'g');
+			});
+		};
+
 		this.cacheable && this.cacheable();
 		var callback = this.async();
 		content = readContent(content, this.context);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "underscore-template-loader",
-	"version": "0.2.5",
+	"version": "0.2.6",
 	"description": "A Underscore template loader for Webpack",
 	"main": "index.js",
 	"homepage": "https://github.com/emaphp/underscore-template-loader",


### PR DESCRIPTION
Love the loader but needed a way to set custom underscore template options to match how we handle templates where I work.  This PR takes in those options via the loader query string and sets them.

Please let me know if I need to do anything else!  Thanks!