### PR TITLE
Add option to prepend the filename in the template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,26 @@ return compiled({name: "world"});
 ```
 
 <br/>
+####Prepending filename comment
+When debugging a large single page app with the DevTools, it's often hard to find the template that contains a bug. With the following config a HTML comment is prepended to the template with the relative path in it (e.g. `<!-- view/user/edit.html -->`).
+
+```javascript
+module.exports = {
+    //...
+    loaders: [
+        //...
+        {
+            test: /\.html$/,
+            loader: "underscore-template-loader",
+            query: {
+              prependFilenameComment: __dirname,
+            }
+        }
+    ]
+};
+```
+
+<br/>
 ####Template settings
 
 <br>

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function () {
 
         if (_.isObject(query)) {
 			// Apply template settings
-			_.each(_.pick(query, 'interpolate', 'escape', 'evaluate'), function (value, key) {
+			_.each(_.pick(query, 'interpolate', 'escape', 'evaluate', 'attributes', 'prependFilenameComment'), function (value, key) {
 				_.templateSettings[key] = new RegExp(value, 'g');
 			});
 
@@ -112,6 +112,14 @@ module.exports = function () {
 
         // Read file content
 		content = readContent(content, this.context);
+
+        // Prepend a html comment with the filename in it
+        if (query.prependFilenameComment) {
+            var filename = loaderUtils.getRemainingRequest(this);
+            var filenameRelative = path.relative(query.prependFilenameComment, filename);
+
+            content = "\n<!-- " + filenameRelative + "  -->\n" + content;
+        }
 
         // Replace random generated strings with require
         var source = _.template(content).source;


### PR DESCRIPTION
This makes it easier to debug a complex app using the DevTools. It prepends a HTML comment in which the path of the template is given (relative to the given value of the option).

At my work, designers can save much time with this because they can see exactly in which file they should look by just opening their DevTools.