### PR TITLE
Add fallback loader

### DIFF
--- a/file-loader.js
+++ b/file-loader.js
@@ -1,0 +1,22 @@
+/* This loader returns the filename if no loader takes care of the file */
+'use strict';
+
+var _ = require('lodash');
+var loaderUtils = require('loader-utils');
+
+module.exports = function (source) {
+  if (this.cacheable) {
+    this.cacheable();
+  }
+  var query = this.query instanceof Object ? this.query : loaderUtils.parseQuery(this.query);
+
+  var allLoadersButThisOne = this.loaders.filter(function(loader) {
+    return loader.module !== module.exports;
+  });
+  // This loader shouldn't kick in if there is any other loader
+  if (allLoadersButThisOne.length > 0) {
+    return source;
+  }
+
+  return query.url;
+};

--- a/file-loader.js
+++ b/file-loader.js
@@ -18,5 +18,5 @@ module.exports = function (source) {
     return source;
   }
 
-  return query.url;
+  return 'module.exports = ' + JSON.stringify(query.url);
 };

--- a/index.js
+++ b/index.js
@@ -83,7 +83,6 @@ module.exports = function(content) {
 
     // Resolve attributes
     source = attributesContext.resolveAttributes(source);
-
     callback(null, "module.exports = " + source + ";");
 };
 

--- a/lib/attributeParser.js
+++ b/lib/attributeParser.js
@@ -63,8 +63,9 @@ AttributeContext.prototype.resolveAttributes = function (content) {
         if (!self.data[match]) {
             return match;
         }
-
-        return "' + require(" + JSON.stringify(loaderUtils.urlToRequest(self.data[match].value, self.root)) + ") + '";
+        var url = (self.data[match].value);
+        var fallbackLoader = require.resolve('../file-loader.js') + '?url=' + encodeURIComponent(url);
+        return "' + require(" + JSON.stringify(fallbackLoader + '!' + loaderUtils.urlToRequest(url, self.root)) + ") + '";
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "name": "Kees Kluskens (SpaceK33z)"
     },
     {
-	  "name": "Pascal (pascalpp)"
+      "name": "Pascal (pascalpp)"
     }
   ],
   "repository": {
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "fastparse": "^1.1.1",
-    "loader-utils": "^0.2.11"
+    "loader-utils": "^0.2.11",
+    "lodash": "^4.0.0"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/test/attributeTest.js
+++ b/test/attributeTest.js
@@ -9,6 +9,8 @@ var attributes = ['img:src', 'link:href'];
 // Helper to test the attributeParser.
 function testMatch(name, html, result) {
     it('should parse ' + name, function() {
+        // The loader has an absolute path so we have to use a placeholder:
+
         var parsed = attributeParser(html, function(tag, attr) {
             return attributes.indexOf(tag + ':' + attr) != -1;
         }, 'ATTRIBUTE', '/asdf/');

--- a/test/lib/loadOutput.js
+++ b/test/lib/loadOutput.js
@@ -2,7 +2,9 @@ var fs = require('fs');
 var path = require('path');
 
 function loadOutput(outputPath) {
-    return fs.readFileSync(path.join(path.dirname(__dirname), 'templates/output', outputPath)).toString();
+    return fs.readFileSync(path.join(path.dirname(__dirname), 'templates/output', outputPath))
+      .toString()
+      .replace(/%%LOADER%%/g, require.resolve('../../file-loader.js'));
 }
 
 module.exports = loadOutput;

--- a/test/templates/output/absolute-image-with-root.txt
+++ b/test/templates/output/absolute-image-with-root.txt
@@ -1,7 +1,7 @@
 module.exports = function(obj){
 var __t,__p='',__j=Array.prototype.join,print=function(){__p+=__j.call(arguments,'');};
 with(obj||{}){
-__p+='<img src="' + require("/bar/asdf.png") + '">\n';
+__p+='<img src="' + require("%%LOADER%%?url=%2Fasdf.png!/bar/asdf.png") + '">\n';
 }
 return __p;
 };

--- a/test/templates/output/custom-attributes.txt
+++ b/test/templates/output/custom-attributes.txt
@@ -1,7 +1,7 @@
 module.exports = function(obj){
 var __t,__p='',__j=Array.prototype.join,print=function(){__p+=__j.call(arguments,'');};
 with(obj||{}){
-__p+='<link rel="stylesheet" href="' + require("./style.css") + '">\n<img src="' + require("./test.png") + '">\n';
+__p+='<link rel="stylesheet" href="' + require("%%LOADER%%?url=style.css!./style.css") + '">\n<img src="' + require("%%LOADER%%?url=test.png!./test.png") + '">\n';
 }
 return __p;
 };

--- a/test/templates/output/image.txt
+++ b/test/templates/output/image.txt
@@ -1,7 +1,7 @@
 module.exports = function(obj){
 var __t,__p='',__j=Array.prototype.join,print=function(){__p+=__j.call(arguments,'');};
 with(obj||{}){
-__p+='<img src="' + require("./nyan.png") + '">\n';
+__p+='<img src="' + require("%%LOADER%%?url=nyan.png!./nyan.png") + '">\n';
 }
 return __p;
 };


### PR DESCRIPTION
I would love to use the underscore-template-loader as the default loader for the html-webpack-plugin.
However this would break as this loader requires a loader for all img tags.

This pull request has a fallback which prevents errors if no image file loader was specified.

See also: #11 