### PR TITLE
Make sure the right engine is available as `_` when withImports is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ module.exports = function(content) {
 
     // Build the module export, optionally with template imports
     if (withImports) {
-        source = 'module.exports = Function(_.keys(_.templateSettings.imports), \'return \' + ' + source + '.toString()).apply(undefined, _.values(_.templateSettings.imports));\n';
+        source = 'module.exports = Function([\'_\'].concat(_.keys(_.templateSettings.imports)), \'return \' + ' + source + '.toString()).apply(undefined, [_].concat(_.values(_.templateSettings.imports)));\n';
     } else {
         source = 'module.exports = ' + source + ';\n';
     }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "chai": "^3.2.0",
     "chai-string": "^1.1.2",
     "istanbul": "^0.3.18",
+    "lodash": "^4.16.2",
     "mocha": "^2.2.5",
+    "require-from-string": "^1.2.0",
     "underscore": "^1.8.3"
   },
   "scripts": {

--- a/test/loaderTest.js
+++ b/test/loaderTest.js
@@ -1,3 +1,6 @@
+var underscore = require('underscore');
+var lodash = require('lodash');
+var requireFromString = require('require-from-string');
 var fs = require('fs');
 var path = require('path');
 var chai = require('chai');
@@ -167,7 +170,53 @@ describe('loader', function () {
             done();
         });
     });
-    
+
+    it('should include the required engine as `_` when withImports is true', function (done) {
+        underscore.ENGINE_NAME = 'UNDERSCORE';
+        lodash.ENGINE_NAME = 'LODASH';
+        _ = lodash;
+
+        testTemplate(loader, 'output-engine-name.html', {
+            query: {
+                engine: 'underscore',
+                withImports: true
+            }
+        }, function (output) {
+            var outputEngineName = requireFromString(output, 'output-engine-name');
+
+            assert.equal('UNDERSCORE', outputEngineName());
+
+            delete _;
+            delete underscore.ENGINE_NAME;
+            delete lodash.ENGINE_NAME;
+
+            done();
+        });
+    });
+
+    it('should include the required engine as `_` when withImports is false', function (done) {
+        underscore.ENGINE_NAME = 'UNDERSCORE';
+        lodash.ENGINE_NAME = 'LODASH';
+        _ = lodash;
+
+        testTemplate(loader, 'output-engine-name.html', {
+            query: {
+                engine: 'underscore',
+                withImports: false
+            }
+        }, function (output) {
+            var outputEngineName = requireFromString(output, 'output-engine-name');
+
+            assert.equal('UNDERSCORE', outputEngineName());
+
+            delete _;
+            delete underscore.ENGINE_NAME;
+            delete lodash.ENGINE_NAME;
+
+            done();
+        });
+    });
+
     // FIXME: Changing the underscore tags changes it globally
     it('should allow custom underscore tags', function (done) {
         testTemplate(loader, 'custom-tags.html', {

--- a/test/templates/output-engine-name.html
+++ b/test/templates/output-engine-name.html
@@ -1,0 +1,1 @@
+<%-_.ENGINE_NAME%>

--- a/test/templates/output/simple-lodash.txt
+++ b/test/templates/output/simple-lodash.txt
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-module.exports = Function(_.keys(_.templateSettings.imports), 'return ' + function(obj){
+module.exports = Function(['_'].concat(_.keys(_.templateSettings.imports)), 'return ' + function(obj){
 var __t,__p='',__j=Array.prototype.join,print=function(){__p+=__j.call(arguments,'');};
 with(obj||{}){
 __p+='<h1>'+
@@ -13,4 +13,4 @@ __p+='\n<p>'+
 __p+='\n';
 }
 return __p;
-}.toString()).apply(undefined, _.values(_.templateSettings.imports));
+}.toString()).apply(undefined, [_].concat(_.values(_.templateSettings.imports)));

--- a/test/templates/output/simple-with-imports.txt
+++ b/test/templates/output/simple-with-imports.txt
@@ -1,4 +1,4 @@
-module.exports = Function(_.keys(_.templateSettings.imports), 'return ' + function(obj){
+module.exports = Function(['_'].concat(_.keys(_.templateSettings.imports)), 'return ' + function(obj){
 var __t,__p='',__j=Array.prototype.join,print=function(){__p+=__j.call(arguments,'');};
 with(obj||{}){
 __p+='<h1>'+
@@ -12,4 +12,4 @@ __p+='\n<p>'+
 __p+='\n';
 }
 return __p;
-}.toString()).apply(undefined, _.values(_.templateSettings.imports));
+}.toString()).apply(undefined, [_].concat(_.values(_.templateSettings.imports)));


### PR DESCRIPTION
The fix is a really small one, it just takes care of adding `_` as the first imported symbol.

For testing I had to actually load the generated module to check what was going on, so I had to add a couple of dependencies, hope you don't mind. Of course I'm open to suggestions and improvements.

Fixes #22