### PR TITLE
Adding support for macros through `this.query`

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,9 @@ module.exports = function(content) {
   if (this.options && _.isObject(this.options.macros)) {
     _.extend(macros, this.options.macros);
   }
+  if (this.query && _.isObject(this.query.macros)) {
+    _.extend(macros, this.query.macros);
+  }
 
   // Parse macros
   if (parseMacros) {


### PR DESCRIPTION
Attempted to add my own macros with webpack 4.43.0 and webpack-dev-server 3.10.3 

Faced issues with `this.options` not being defined in the loader, according to the webpack documentation the option are available under `this.query`: https://webpack.js.org/api/loaders/#thisquery

see https://github.com/devlinjunker/template.webpack.fend/pull/22/files#diff-11e9f7f953edc64ba14b0cc350ae7b9dR162 for the implementation where it is not working (unless we add this fix)