### PR TITLE
Updated README for custom macros options setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ We can include additional macros by defining them in the webpack configuration f
 
 ```javascript
 // File: webpack.config.js
+const webpack = require('webpack');
+
 module.exports = {
     // ...
 
@@ -330,11 +332,18 @@ module.exports = {
         }
     },
 
-    macros: {
-        copyright: function () {
-            return "'<p>Copyright FakeCorp 2014 - 2016</p>'";
-        }
-    }
+    plugins: [
+        // ...
+        new webpack.LoaderOptionsPlugin({
+            options: {
+                macros: {
+                    copyright: function () {
+                        return "'<p>Copyright FakeCorp 2014 - 2018</p>'";
+                    },
+                },
+            },
+        }),
+    ],
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -427,6 +427,23 @@ Translates to
 <br>
 ```
 
+### Just an example of requiring template with dynamic arguments
+
+```javascript
+<%
+    const title = 'Some ' + 'title';
+    const headFileName = htmlWebpackPlugin.options.headFileName || 'head.ejs';
+
+    function objExtend(args, obj) {
+        args = Array.prototype.slice.call(args);
+        args[0] = Object.assign(obj, args[0]);
+        return args;
+    };
+%>
+
+<%= require(`./structure/${headFileName}`).apply(null, objExtend(arguments, { title })) %>
+```
+
 #### Known issues
 
  * Trying to use different template settings (interpolate, escape, evaluate) for different extensions. Underscore / Lodash template settings are defined globally.


### PR DESCRIPTION
Webpack has stopped supporting custom options right in Webpack config object, so this PR adds to README file a workaround for adding `options` object for the loader.

Re-created from #34 